### PR TITLE
docs: add guide for vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vs*/
 
 # files
 *.zip
+compile_commands.json

--- a/README.md
+++ b/README.md
@@ -21,9 +21,32 @@ xmake build
 > ***Note:*** *This will generate a `build/windows/` directory in the **project's root directory** with the build output.*
 
 ### Project Generation (Optional)
+
+#### Visual studio
 If you want to generate a Visual Studio project, run the following command:
 ```bat
 xmake project -k vsxmake
 ```
 
 > ***Note:*** *This will generate a `vsxmakeXXXX/` directory in the **project's root directory** using the latest version of Visual Studio installed on the system.*
+
+#### VSCode
+If you want to generate a compile_commands.json (for use with vscode for example), run the following command:
+```bat
+xmake project -k compile_commands --lsp=clangd
+```
+
+> ***Note:*** *This will generate a `compile_commands.json` file in the **project's root directory**.*
+
+Add this to `.vscode/c_cpp_properties.json` (Requires extension ms-vscode.cpptools)
+```json
+{
+    "configurations": [
+        {
+            //...existing configuration
+            "compileCommands": "${workspaceFolder}/compile_commands.json"
+        }
+    ],
+    "version": 4
+}
+```


### PR DESCRIPTION
With the steps specified in the readme for vscode this template will also work in vscode
![image](https://github.com/Starfield-Reverse-Engineering/commonlibsf-template-xmake/assets/964655/259735d8-208b-4a45-95de-137eaed8dd17)

Using this xmake command `xmake project -k compile_commands --lsp=clangd`
The `--lsp=clangd` is needed to not clear the `pcxxheader` when generating the `compile_commands.json`
